### PR TITLE
Const Assignment Map Fusion Draft PR

### DIFF
--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -356,6 +356,10 @@ def consume_map_with_grid_strided_loop(graph: SDFGState, dst: tuple[MapEntry, Ma
                               src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
                               memlet=Memlet.from_memlet(e.data))
         graph.remove_edge(e)
+    if len(graph.in_edges(en)) == 0:
+        graph.add_memlet_path(dst_en, en, memlet=Memlet())
+    if len(graph.out_edges(ex)) == 0:
+        graph.add_memlet_path(ex, dst_ex, memlet=Memlet())
 
 
 def fused_range(r1: Range, r2: Range) -> Optional[Range]:
@@ -511,6 +515,7 @@ class ConstAssignmentMapFusion(MapFusion):
                                                                          second_entry.map.range))},
                                schedule=first_entry.map.schedule)
         for cur_en, cur_ex in [(first_entry, first_exit), (second_entry, second_exit)]:
+            assert en.map.range.covers(cur_en.map.range) or self.use_grid_strided_loops
             if en.map.range.covers(cur_en.map.range):
                 consume_map_exactly(graph, (en, ex), (cur_en, cur_ex))
             elif self.use_grid_strided_loops:

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -514,12 +514,16 @@ class ConstAssignmentMapFusion(MapFusion):
                                                              fused_range(first_entry.map.range,
                                                                          second_entry.map.range))},
                                schedule=first_entry.map.schedule)
-        for cur_en, cur_ex in [(first_entry, first_exit), (second_entry, second_exit)]:
-            assert en.map.range.covers(cur_en.map.range) or self.use_grid_strided_loops
-            if en.map.range.covers(cur_en.map.range):
+        if first_entry.map.range == second_entry.map.range:
+            for cur_en, cur_ex in [(first_entry, first_exit), (second_entry, second_exit)]:
                 consume_map_exactly(graph, (en, ex), (cur_en, cur_ex))
-            elif self.use_grid_strided_loops:
-                consume_map_with_grid_strided_loop(graph, (en, ex), (cur_en, cur_ex))
+        elif self.use_grid_strided_loops:
+            assert ScheduleType.Sequential not in [first_entry.map.schedule, second_entry.map.schedule]
+            for cur_en, cur_ex in [(first_entry, first_exit), (second_entry, second_exit)]:
+                if en.map.range == cur_en.map.range:
+                    consume_map_exactly(graph, (en, ex), (cur_en, cur_ex))
+                else:
+                    consume_map_with_grid_strided_loop(graph, (en, ex), (cur_en, cur_ex))
 
         # Cleanup: remove duplicate empty dependencies.
         seen = set()

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -5,7 +5,6 @@ from itertools import chain
 from typing import Optional, Union
 
 from dace import transformation, SDFGState, SDFG, Memlet, subsets, ScheduleType
-from dace.sdfg import nodes
 from dace.sdfg.graph import OrderedDiGraph
 from dace.sdfg.nodes import Tasklet, ExitNode, MapEntry, MapExit, NestedSDFG, Node, EntryNode, AccessNode
 from dace.sdfg.state import ControlFlowBlock, ControlFlowRegion
@@ -31,6 +30,351 @@ def floating_nodes_graph(*args):
     return g
 
 
+def consistent_branch_const_assignment_table(graph: Node) -> tuple[bool, dict]:
+    """
+    If the graph consists of only conditional consistent constant assignments, produces a table mapping data arrays
+    and memlets to their consistent constant assignments. See the class docstring for what is considered consistent.
+    """
+    table = {}
+    # Basic premise check.
+    if not isinstance(graph, NestedSDFG):
+        return False, table
+    graph: SDFG = graph.sdfg
+    if not isinstance(graph, ControlFlowBlock):
+        return False, table
+
+    # Must have exactly 3 nodes, and exactly one of them a source, another a sink.
+    src, snk = graph.source_nodes(), graph.sink_nodes()
+    if len(graph.nodes()) != 3 or len(src) != 1 or len(snk) != 1:
+        return False, table
+    src, snk = src[0], snk[0]
+    body = set(graph.nodes()) - {src, snk}
+    if len(body) != 1:
+        return False, table
+    body = list(body)[0]
+
+    # Must have certain structure of outgoing edges.
+    src_eds = list(graph.out_edges(src))
+    if len(src_eds) != 2 or any(e.data.is_unconditional() or e.data.assignments for e in src_eds):
+        return False, table
+    tb, el = src_eds
+    if tb.dst != body:
+        tb, el = el, tb
+    if tb.dst != body or el.dst != snk:
+        return False, table
+    body_eds = list(graph.out_edges(body))
+    if len(body_eds) != 1 or body_eds[0].dst != snk or not body_eds[0].data.is_unconditional() or body_eds[
+        0].data.assignments:
+        return False, table
+
+    # Branch conditions must depend only on the loop variables.
+    for b in [tb, el]:
+        cond = b.data.condition
+        for c in cond.code:
+            used = set([ast_node.id for ast_node in ast.walk(c) if isinstance(ast_node, ast.Name)])
+            if not used.issubset(graph.free_symbols):
+                return False, table
+
+    # Body must have only constant assignments.
+    for n, _ in body.all_nodes_recursive():
+        # Each tasklet in this box...
+        if not isinstance(n, Tasklet):
+            continue
+        if len(n.code.code) != 1 or not isinstance(n.code.code[0], ast.Assign):
+            # ...must assign...
+            return False, table
+        op = n.code.code[0]
+        if not isinstance(op.value, ast.Constant) or len(op.targets) != 1:
+            # ...a constant to a single target.
+            return False, table
+        const = op.value.value
+        for oe in body.out_edges(n):
+            dst = oe.data
+            dst_arr = oe.data.data
+            if dst_arr in table and table[dst_arr] != const:
+                # A target array can appear multiple times, but it must always be consistently assigned.
+                return False, table
+            table[dst] = const
+            table[dst_arr] = const
+    return True, table
+
+
+def consistent_const_assignment_table(graph: SDFGState, en: MapEntry, ex: MapExit) -> tuple[bool, dict]:
+    """
+    If the graph consists of only (conditional or unconditional) consistent constant assignments, produces a table
+    mapping data arrays and memlets to their consistent constant assignments. See the class docstring for what is
+    considered consistent.
+    """
+    table = {}
+    for n in graph.all_nodes_between(en, ex):
+        if isinstance(n, NestedSDFG):
+            # First handle the case of conditional constant assignment.
+            is_branch_const_assignment, internal_table = consistent_branch_const_assignment_table(n)
+            if not is_branch_const_assignment:
+                return False, table
+            for oe in graph.out_edges(n):
+                dst = oe.data
+                dst_arr = oe.data.data
+                if dst_arr in table and table[dst_arr] != internal_table[oe.src_conn]:
+                    # A target array can appear multiple times, but it must always be consistently assigned.
+                    return False, table
+                table[dst] = internal_table[oe.src_conn]
+                table[dst_arr] = internal_table[oe.src_conn]
+        elif isinstance(n, MapEntry):
+            is_const_assignment, internal_table = consistent_const_assignment_table(graph, n, graph.exit_node(n))
+            if not is_const_assignment:
+                return False, table
+            for k, v in internal_table.items():
+                if k in table and v != table[k]:
+                    return False, table
+                internal_table[k] = v
+        elif isinstance(n, MapExit):
+            pass  # Handled with `MapEntry`
+        else:
+            # Each of the nodes in this map must be...
+            if not isinstance(n, Tasklet):
+                # ...a tasklet...
+                return False, table
+            if len(n.code.code) != 1 or not isinstance(n.code.code[0], ast.Assign):
+                # ...that assigns...
+                return False, table
+            op = n.code.code[0]
+            if not isinstance(op.value, ast.Constant) or len(op.targets) != 1:
+                # ...a constant to a single target.
+                return False, table
+            const = op.value.value
+            for oe in graph.out_edges(n):
+                dst = oe.data
+                dst_arr = oe.data.data
+                if dst_arr in table and table[dst_arr] != const:
+                    # A target array can appear multiple times, but it must always be consistently assigned.
+                    return False, table
+                table[dst] = const
+                table[dst_arr] = const
+    return True, table
+
+
+def add_equivalent_connectors(dst: Union[EntryNode, ExitNode], src: Union[EntryNode, ExitNode]):
+    """
+    Create the additional connectors in the first exit node that matches the second exit node (which will be removed
+    later).
+    """
+    conn_map = defaultdict()
+    for c, v in src.in_connectors.items():
+        assert c.startswith('IN_')
+        cbase = c.removeprefix('IN_')
+        sc = dst.next_connector(cbase)
+        conn_map[f"IN_{cbase}"] = f"IN_{sc}"
+        conn_map[f"OUT_{cbase}"] = f"OUT_{sc}"
+        dst.add_in_connector(f"IN_{sc}", dtype=v)
+        dst.add_out_connector(f"OUT_{sc}", dtype=v)
+    for c, v in src.out_connectors.items():
+        assert c in conn_map
+    return conn_map
+
+
+def connector_counterpart(c: Union[str, None]) -> Union[str, None]:
+    """If it's an input connector, find the corresponding output connector, and vice versa."""
+    if c is None:
+        return None
+    assert isinstance(c, str)
+    if c.startswith('IN_'):
+        return f"OUT_{c.removeprefix('IN_')}"
+    elif c.startswith('OUT_'):
+        return f"IN_{c.removeprefix('OUT_')}"
+    return None
+
+
+def consolidate_empty_dependencies(graph: SDFGState, first_entry: MapEntry, second_entry: MapEntry):
+    """
+    Remove all the incoming edges of the two maps and add empty edges from the union of the access nodes they
+    depended on before.
+
+    Preconditions:
+    1. All the incoming edges of the two maps must be from an access node and empty (i.e. have existed
+    only for synchronization).
+    2. The two maps must be constistent const assignments (see the class docstring for what is considered
+    consistent).
+    """
+    # First, construct a table of the dependencies.
+    table = {}
+    for en in [first_entry, second_entry]:
+        for e in graph.in_edges(en):
+            assert e.data.is_empty()
+            assert e.src_conn is None and e.dst_conn is None
+            if not isinstance(e.src, AccessNode):
+                continue
+            if e.src.data not in table:
+                table[e.src.data] = e.src
+            elif table[e.src.data] in graph.bfs_nodes(e.src):
+                # If this copy of the node is above the copy we've seen before, use this one instead.
+                table[e.src.data] = e.src
+            graph.remove_edge(e)
+    # Then, if we still have so that any of the map _writes_ to these nodes, we want to just create fresh copies to
+    # avoid cycles.
+    alt_table = {}
+    for k, v in table.items():
+        if v in graph.bfs_nodes(first_entry) or v in graph.bfs_nodes(second_entry):
+            alt_v = deepcopy(v)
+            graph.add_node(alt_v)
+            alt_table[k] = alt_v
+        else:
+            alt_table[k] = v
+    # Finally, these nodes should be depended on by _both_ maps.
+    for en in [first_entry, second_entry]:
+        for n in alt_table.values():
+            graph.add_memlet_path(n, en, memlet=Memlet())
+
+
+def consolidate_written_nodes(graph: SDFGState, first_exit: MapExit, second_exit: MapExit):
+    """
+    If the two maps write to the same underlying data array through two access nodes, replace those edges'
+    destination with a single shared copy.
+
+    Precondition:
+    1. The two maps must not depend on each other through an access node, which should be taken care of already by
+    `consolidate_empty_dependencies()`.
+    2. The two maps must be constistent const assignments (see the class docstring for what is considered
+    consistent).
+    """
+    # First, construct tables of the surviving and all written access nodes.
+    surviving_nodes, all_written_nodes = {}, set()
+    for ex in [first_exit, second_exit]:
+        for e in graph.out_edges(ex):
+            assert not e.data.is_empty()
+            assert e.src_conn is not None and ((e.dst_conn is None) == isinstance(e.dst, AccessNode))
+            if not isinstance(e.dst, AccessNode):
+                continue
+            all_written_nodes.add(e.dst)
+            if e.dst.data not in surviving_nodes:
+                surviving_nodes[e.dst.data] = e.dst
+            elif e.dst in graph.bfs_nodes(surviving_nodes[e.dst.data]):
+                # If this copy of the node is above the copy we've seen before, use this one instead.
+                surviving_nodes[e.dst.data] = e.dst
+    # Then, redirect all the edges toward the surviving copies of the destination access nodes.
+    for n in all_written_nodes:
+        for e in graph.in_edges(n):
+            assert e.src in [first_exit, second_exit]
+            assert e.dst_conn is None
+            graph.add_memlet_path(e.src, surviving_nodes[e.dst.data],
+                                  src_conn=e.src_conn, dst_conn=e.dst_conn,
+                                  memlet=Memlet.from_memlet(e.data))
+            graph.remove_edge(e)
+        for e in graph.out_edges(n):
+            assert e.src_conn is None
+            graph.add_memlet_path(surviving_nodes[e.src.data], e.dst,
+                                  src_conn=e.src_conn, dst_conn=e.dst_conn,
+                                  memlet=Memlet.from_memlet(e.data))
+            graph.remove_edge(e)
+    # Finally, cleanup the orphan nodes.
+    for n in all_written_nodes:
+        if graph.degree(n) == 0:
+            graph.remove_node(n)
+
+
+def consume_map_exactly(graph: SDFGState, dst: tuple[MapEntry, MapExit], src: tuple[MapEntry, MapExit]):
+    """
+    Transfer the entirety of `src` map's body into `dst` map. Only possible when the two maps' ranges are identical.
+    """
+    dst_en, dst_ex = dst
+    src_en, src_ex = src
+
+    assert all(e.data.is_empty() for e in graph.in_edges(src_en))
+    cmap = add_equivalent_connectors(dst_en, src_en)
+    for e in graph.in_edges(src_en):
+        graph.add_memlet_path(e.src, dst_en,
+                              src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+    for e in graph.out_edges(src_en):
+        graph.add_memlet_path(dst_en, e.dst,
+                              src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+
+    cmap = add_equivalent_connectors(dst_ex, src_ex)
+    for e in graph.in_edges(src_ex):
+        graph.add_memlet_path(e.src, dst_ex,
+                              src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+    for e in graph.out_edges(src_ex):
+        graph.add_memlet_path(dst_ex, e.dst,
+                              src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+
+    graph.remove_node(src_en)
+    graph.remove_node(src_ex)
+
+
+def consume_map_with_grid_strided_loop(graph: SDFGState, dst: tuple[MapEntry, MapExit],
+                                       src: tuple[MapEntry, MapExit]):
+    """
+    Transfer the entirety of `src` map's body into `dst` map, guarded behind a _grid-strided_ loop.
+    Prerequisite: `dst` map's range must cover `src` map's range in entirety. Statically checking this may not
+    always be possible.
+    """
+    dst_en, dst_ex = dst
+    src_en, src_ex = src
+
+    def range_for_grid_stride(r, val, bound):
+        r = list(r)
+        r[0] = val
+        r[1] = bound - 1
+        r[2] = bound
+        return tuple(r)
+
+    gsl_ranges = [range_for_grid_stride(rd, p, rs[1] + 1)
+                  for p, rs, rd in zip(dst_en.map.params, src_en.map.range.ranges, dst_en.map.range.ranges)]
+    gsl_params = [f"gsl_{p}" for p in dst_en.map.params]
+    en, ex = graph.add_map(graph.sdfg._find_new_name('gsl'),
+                           {k: v for k, v in zip(gsl_params, gsl_ranges)},
+                           schedule=ScheduleType.Sequential)
+    # graph.add_memlet_path(dst_en, en, memlet=Memlet())
+    consume_map_exactly(graph, (en, ex), src)
+    # graph.add_memlet_path(ex, dst_ex, memlet=Memlet())
+
+    assert all(e.data.is_empty() for e in graph.in_edges(en))
+    cmap = add_equivalent_connectors(dst_en, en)
+    for e in graph.in_edges(en):
+        graph.add_memlet_path(e.src, dst_en,
+                              src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
+                              memlet=Memlet.from_memlet(e.data))
+        graph.add_memlet_path(dst_en, e.dst,
+                              src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+
+    cmap = add_equivalent_connectors(dst_ex, ex)
+    for e in graph.out_edges(ex):
+        graph.add_memlet_path(e.src, dst_ex,
+                              src_conn=e.src_conn,
+                              dst_conn=connector_counterpart(cmap.get(e.src_conn)),
+                              memlet=Memlet.from_memlet(e.data))
+        graph.add_memlet_path(dst_ex, e.dst,
+                              src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
+                              memlet=Memlet.from_memlet(e.data))
+        graph.remove_edge(e)
+
+
+def compatible_range(first_entry: MapEntry, second_entry: MapEntry) -> bool:
+    """Decide if the two ranges are compatible. See the class docstring for what is considered compatible."""
+    if first_entry.map.schedule != second_entry.map.schedule:
+        # If the two maps are not to be scheduled on the same device, don't fuse them.
+        return False
+    if len(first_entry.map.range) != len(second_entry.map.range):
+        # If it's not even possible to take component-wise union of the two map's range, don't fuse them.
+        # TODO(pratyai): Make it so that a permutation of the ranges, or even an union of the ranges will work.
+        return False
+    if first_entry.map.schedule == ScheduleType.Sequential:
+        # For _grid-strided loops_, fuse them only when their ranges are _exactly_ the same. I.e., never put them
+        # behind another layer of grid-strided loop.
+        if first_entry.map.range != second_entry.map.range:
+            return False
+    return True
+
+
 class ConstAssignmentMapFusion(MapFusion):
     """
     Fuses two maps within a state, where each map:
@@ -47,8 +391,8 @@ class ConstAssignmentMapFusion(MapFusion):
         - Exists a path like: MapExit -> AccessNode -> MapEntry
         - Neither map is dependent on the other. I.e. There is no dependency path between them.
     """
-    first_map_entry = transformation.PatternNode(nodes.EntryNode)
-    second_map_entry = transformation.PatternNode(nodes.EntryNode)
+    first_map_entry = transformation.PatternNode(MapEntry)
+    second_map_entry = transformation.PatternNode(MapEntry)
 
     @classmethod
     def expressions(cls):
@@ -56,155 +400,10 @@ class ConstAssignmentMapFusion(MapFusion):
         # in the middle and the second edge of the path is empty.
         return [floating_nodes_graph(cls.first_map_entry, cls.second_map_entry)]
 
-    @staticmethod
-    def consistent_branch_const_assignment_table(graph: Node) -> tuple[bool, dict]:
-        """
-        If the graph consists of only conditional consistent constant assignments, produces a table mapping data arrays
-        and memlets to their consistent constant assignments. See the class docstring for what is considered consistent.
-        """
-        table = {}
-        # Basic premise check.
-        if not isinstance(graph, NestedSDFG):
-            return False, table
-        graph: SDFG = graph.sdfg
-        if not isinstance(graph, ControlFlowBlock):
-            return False, table
-
-        # Must have exactly 3 nodes, and exactly one of them a source, another a sink.
-        src, snk = graph.source_nodes(), graph.sink_nodes()
-        if len(graph.nodes()) != 3 or len(src) != 1 or len(snk) != 1:
-            return False, table
-        src, snk = src[0], snk[0]
-        body = set(graph.nodes()) - {src, snk}
-        if len(body) != 1:
-            return False, table
-        body = list(body)[0]
-
-        # Must have certain structure of outgoing edges.
-        src_eds = list(graph.out_edges(src))
-        if len(src_eds) != 2 or any(e.data.is_unconditional() or e.data.assignments for e in src_eds):
-            return False, table
-        tb, el = src_eds
-        if tb.dst != body:
-            tb, el = el, tb
-        if tb.dst != body or el.dst != snk:
-            return False, table
-        body_eds = list(graph.out_edges(body))
-        if len(body_eds) != 1 or body_eds[0].dst != snk or not body_eds[0].data.is_unconditional() or body_eds[
-            0].data.assignments:
-            return False, table
-
-        # Branch conditions must depend only on the loop variables.
-        for b in [tb, el]:
-            cond = b.data.condition
-            for c in cond.code:
-                used = set([ast_node.id for ast_node in ast.walk(c) if isinstance(ast_node, ast.Name)])
-                if not used.issubset(graph.free_symbols):
-                    return False, table
-
-        # Body must have only constant assignments.
-        for n, _ in body.all_nodes_recursive():
-            # Each tasklet in this box...
-            if not isinstance(n, Tasklet):
-                continue
-            if len(n.code.code) != 1 or not isinstance(n.code.code[0], ast.Assign):
-                # ...must assign...
-                return False, table
-            op = n.code.code[0]
-            if not isinstance(op.value, ast.Constant) or len(op.targets) != 1:
-                # ...a constant to a single target.
-                return False, table
-            const = op.value.value
-            for oe in body.out_edges(n):
-                dst = oe.data
-                dst_arr = oe.data.data
-                if dst_arr in table and table[dst_arr] != const:
-                    # A target array can appear multiple times, but it must always be consistently assigned.
-                    return False, table
-                table[dst] = const
-                table[dst_arr] = const
-        return True, table
-
-    @staticmethod
-    def consistent_const_assignment_table(graph: SDFGState, en: MapEntry, ex: MapExit) -> tuple[bool, dict]:
-        """
-        If the graph consists of only (conditional or unconditional) consistent constant assignments, produces a table
-        mapping data arrays and memlets to their consistent constant assignments. See the class docstring for what is
-        considered consistent.
-        """
-        table = {}
-        for n in graph.all_nodes_between(en, ex):
-            if isinstance(n, NestedSDFG):
-                # First handle the case of conditional constant assignment.
-                is_branch_const_assignment, internal_table = ConstAssignmentMapFusion.consistent_branch_const_assignment_table(
-                    n)
-                if not is_branch_const_assignment:
-                    return False, table
-                for oe in graph.out_edges(n):
-                    dst = oe.data
-                    dst_arr = oe.data.data
-                    if dst_arr in table and table[dst_arr] != internal_table[oe.src_conn]:
-                        # A target array can appear multiple times, but it must always be consistently assigned.
-                        return False, table
-                    table[dst] = internal_table[oe.src_conn]
-                    table[dst_arr] = internal_table[oe.src_conn]
-            elif isinstance(n, MapEntry):
-                is_const_assignment, internal_table = ConstAssignmentMapFusion.consistent_const_assignment_table(graph,
-                                                                                                                 n,
-                                                                                                                 graph.exit_node(
-                                                                                                                     n))
-                if not is_const_assignment:
-                    return False, table
-                for k, v in internal_table.items():
-                    if k in table and v != table[k]:
-                        return False, table
-                    internal_table[k] = v
-            elif isinstance(n, MapExit):
-                pass  # Handled with `MapEntry`
-            else:
-                # Each of the nodes in this map must be...
-                if not isinstance(n, Tasklet):
-                    # ...a tasklet...
-                    return False, table
-                if len(n.code.code) != 1 or not isinstance(n.code.code[0], ast.Assign):
-                    # ...that assigns...
-                    return False, table
-                op = n.code.code[0]
-                if not isinstance(op.value, ast.Constant) or len(op.targets) != 1:
-                    # ...a constant to a single target.
-                    return False, table
-                const = op.value.value
-                for oe in graph.out_edges(n):
-                    dst = oe.data
-                    dst_arr = oe.data.data
-                    if dst_arr in table and table[dst_arr] != const:
-                        # A target array can appear multiple times, but it must always be consistently assigned.
-                        return False, table
-                    table[dst] = const
-                    table[dst_arr] = const
-        return True, table
-
     def map_nodes(self, graph: SDFGState):
         """Return the entry and exit nodes of the relevant maps as a tuple: entry_1, exit_1, entry_2, exit_2."""
         return (self.first_map_entry, graph.exit_node(self.first_map_entry),
                 self.second_map_entry, graph.exit_node(self.second_map_entry))
-
-    @staticmethod
-    def compatible_range(first_entry: MapEntry, second_entry: MapEntry) -> bool:
-        """Decide if the two ranges are compatible. See the class docstring for what is considered compatible."""
-        if first_entry.map.schedule != second_entry.map.schedule:
-            # If the two maps are not to be scheduled on the same device, don't fuse them.
-            return False
-        if len(first_entry.map.range) != len(second_entry.map.range):
-            # If it's not even possible to take component-wise union of the two map's range, don't fuse them.
-            # TODO(pratyai): Make it so that a permutation of the ranges, or even an union of the ranges will work.
-            return False
-        if first_entry.map.schedule == ScheduleType.Sequential:
-            # For _grid-strided loops_, fuse them only when their ranges are _exactly_ the same. I.e., never put them
-            # behind another layer of grid-strided loop.
-            if first_entry.map.range != second_entry.map.range:
-                return False
-        return True
 
     def no_dependency_pattern(self, graph: SDFGState) -> bool:
         """Decide if the two maps are independent of each other."""
@@ -239,15 +438,14 @@ class ConstAssignmentMapFusion(MapFusion):
             return False
 
         first_entry, first_exit, second_entry, second_exit = self.map_nodes(graph)
-        if not self.compatible_range(first_entry, second_entry):
+        if not compatible_range(first_entry, second_entry):
             return False
 
         # Both maps must have consistent constant assignment for the target arrays.
-        is_const_assignment, assignments = self.consistent_const_assignment_table(graph, first_entry, first_exit)
+        is_const_assignment, assignments = consistent_const_assignment_table(graph, first_entry, first_exit)
         if not is_const_assignment:
             return False
-        is_const_assignment, further_assignments = self.consistent_const_assignment_table(graph, second_entry,
-                                                                                          second_exit)
+        is_const_assignment, further_assignments = consistent_const_assignment_table(graph, second_entry, second_exit)
         if not is_const_assignment:
             return False
         for k, v in further_assignments.items():
@@ -256,216 +454,12 @@ class ConstAssignmentMapFusion(MapFusion):
             assignments[k] = v
         return True
 
-    @staticmethod
-    def add_equivalent_connectors(dst: Union[EntryNode, ExitNode], src: Union[EntryNode, ExitNode]):
-        """
-        Create the additional connectors in the first exit node that matches the second exit node (which will be removed
-        later).
-        """
-        conn_map = defaultdict()
-        for c, v in src.in_connectors.items():
-            assert c.startswith('IN_')
-            cbase = c.removeprefix('IN_')
-            sc = dst.next_connector(cbase)
-            conn_map[f"IN_{cbase}"] = f"IN_{sc}"
-            conn_map[f"OUT_{cbase}"] = f"OUT_{sc}"
-            dst.add_in_connector(f"IN_{sc}", dtype=v)
-            dst.add_out_connector(f"OUT_{sc}", dtype=v)
-        for c, v in src.out_connectors.items():
-            assert c in conn_map
-        return conn_map
-
-    @staticmethod
-    def connector_counterpart(c: Union[str, None]) -> Union[str, None]:
-        """If it's an input connector, find the corresponding output connector, and vice versa."""
-        if c is None:
-            return None
-        assert isinstance(c, str)
-        if c.startswith('IN_'):
-            return f"OUT_{c.removeprefix('IN_')}"
-        elif c.startswith('OUT_'):
-            return f"IN_{c.removeprefix('OUT_')}"
-        return None
-
-    @staticmethod
-    def consolidate_empty_dependencies(graph: SDFGState, first_entry: MapEntry, second_entry: MapEntry):
-        """
-        Remove all the incoming edges of the two maps and add empty edges from the union of the access nodes they
-        depended on before.
-
-        Preconditions:
-        1. All the incoming edges of the two maps must be from an access node and empty (i.e. have existed
-        only for synchronization).
-        2. The two maps must be constistent const assignments (see the class docstring for what is considered
-        consistent).
-        """
-        # First, construct a table of the dependencies.
-        table = {}
-        for en in [first_entry, second_entry]:
-            for e in graph.in_edges(en):
-                assert e.data.is_empty()
-                assert e.src_conn is None and e.dst_conn is None
-                if not isinstance(e.src, AccessNode):
-                    continue
-                if e.src.data not in table:
-                    table[e.src.data] = e.src
-                elif table[e.src.data] in graph.bfs_nodes(e.src):
-                    # If this copy of the node is above the copy we've seen before, use this one instead.
-                    table[e.src.data] = e.src
-                graph.remove_edge(e)
-        # Then, if we still have so that any of the map _writes_ to these nodes, we want to just create fresh copies to
-        # avoid cycles.
-        alt_table = {}
-        for k, v in table.items():
-            if v in graph.bfs_nodes(first_entry) or v in graph.bfs_nodes(second_entry):
-                alt_v = deepcopy(v)
-                graph.add_node(alt_v)
-                alt_table[k] = alt_v
-            else:
-                alt_table[k] = v
-        # Finally, these nodes should be depended on by _both_ maps.
-        for en in [first_entry, second_entry]:
-            for n in alt_table.values():
-                graph.add_memlet_path(n, en, memlet=Memlet())
-
-    @staticmethod
-    def consolidate_written_nodes(graph: SDFGState, first_exit: MapExit, second_exit: MapExit):
-        """
-        If the two maps write to the same underlying data array through two access nodes, replace those edges'
-        destination with a single shared copy.
-
-        Precondition:
-        1. The two maps must not depend on each other through an access node (which should be taken care of already by
-        `consolidate_empty_dependencies()`.
-        2. The two maps must be constistent const assignments (see the class docstring for what is considered
-        consistent).
-        """
-        # First, construct tables of the surviving and all written access nodes.
-        surviving_nodes, all_written_nodes = {}, set()
-        for ex in [first_exit, second_exit]:
-            for e in graph.out_edges(ex):
-                assert not e.data.is_empty()
-                assert e.src_conn is not None and ((e.dst_conn is None) == isinstance(e.dst, AccessNode))
-                if not isinstance(e.dst, AccessNode):
-                    continue
-                all_written_nodes.add(e.dst)
-                if e.dst.data not in surviving_nodes:
-                    surviving_nodes[e.dst.data] = e.dst
-                elif e.dst in graph.bfs_nodes(surviving_nodes[e.dst.data]):
-                    # If this copy of the node is above the copy we've seen before, use this one instead.
-                    surviving_nodes[e.dst.data] = e.dst
-        # Then, redirect all the edges toward the surviving copies of the destination access nodes.
-        for n in all_written_nodes:
-            for e in graph.in_edges(n):
-                assert e.src in [first_exit, second_exit]
-                assert e.dst_conn is None
-                graph.add_memlet_path(e.src, surviving_nodes[e.dst.data],
-                                      src_conn=e.src_conn, dst_conn=e.dst_conn,
-                                      memlet=Memlet.from_memlet(e.data))
-                graph.remove_edge(e)
-            for e in graph.out_edges(n):
-                assert e.src_conn is None
-                graph.add_memlet_path(surviving_nodes[e.src.data], e.dst,
-                                      src_conn=e.src_conn, dst_conn=e.dst_conn,
-                                      memlet=Memlet.from_memlet(e.data))
-                graph.remove_edge(e)
-        # Finally, cleanup the orphan nodes.
-        for n in all_written_nodes:
-            if graph.degree(n) == 0:
-                graph.remove_node(n)
-
-    @staticmethod
-    def consume_map_exactly(graph: SDFGState, dst: tuple[MapEntry, MapExit], src: tuple[MapEntry, MapExit]):
-        """
-        Transfer the entirety of `src` map's body into `dst` map. Only possible when the two maps' ranges are identical.
-        """
-        dst_en, dst_ex = dst
-        src_en, src_ex = src
-
-        assert all(e.data.is_empty() for e in graph.in_edges(src_en))
-        cmap = ConstAssignmentMapFusion.add_equivalent_connectors(dst_en, src_en)
-        for e in graph.in_edges(src_en):
-            graph.add_memlet_path(e.src, dst_en,
-                                  src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-        for e in graph.out_edges(src_en):
-            graph.add_memlet_path(dst_en, e.dst,
-                                  src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-
-        cmap = ConstAssignmentMapFusion.add_equivalent_connectors(dst_ex, src_ex)
-        for e in graph.in_edges(src_ex):
-            graph.add_memlet_path(e.src, dst_ex,
-                                  src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-        for e in graph.out_edges(src_ex):
-            graph.add_memlet_path(dst_ex, e.dst,
-                                  src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-
-        graph.remove_node(src_en)
-        graph.remove_node(src_ex)
-
-    @staticmethod
-    def consume_map_with_grid_strided_loop(graph: SDFGState, dst: tuple[MapEntry, MapExit],
-                                           src: tuple[MapEntry, MapExit]):
-        """
-        Transfer the entirety of `src` map's body into `dst` map, guarded behind a _grid-strided_ loop.
-        Prerequisite: `dst` map's range must cover `src` map's range in entirety. Statically checking this may not
-        always be possible.
-        """
-        dst_en, dst_ex = dst
-        src_en, src_ex = src
-
-        def range_for_grid_stride(r, val, bound):
-            r = list(r)
-            r[0] = val
-            r[1] = bound - 1
-            r[2] = bound
-            return tuple(r)
-
-        gsl_ranges = [range_for_grid_stride(rd, p, rs[1] + 1)
-                      for p, rs, rd in zip(dst_en.map.params, src_en.map.range.ranges, dst_en.map.range.ranges)]
-        gsl_params = [f"gsl_{p}" for p in dst_en.map.params]
-        en, ex = graph.add_map(graph.sdfg._find_new_name('gsl'),
-                               {k: v for k, v in zip(gsl_params, gsl_ranges)},
-                               schedule=ScheduleType.Sequential)
-        # graph.add_memlet_path(dst_en, en, memlet=Memlet())
-        ConstAssignmentMapFusion.consume_map_exactly(graph, (en, ex), src)
-        # graph.add_memlet_path(ex, dst_ex, memlet=Memlet())
-
-        assert all(e.data.is_empty() for e in graph.in_edges(en))
-        cmap = ConstAssignmentMapFusion.add_equivalent_connectors(dst_en, en)
-        for e in graph.in_edges(en):
-            graph.add_memlet_path(e.src, dst_en,
-                                  src_conn=e.src_conn, dst_conn=cmap.get(e.dst_conn),
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.add_memlet_path(dst_en, e.dst,
-                                  src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-
-        cmap = ConstAssignmentMapFusion.add_equivalent_connectors(dst_ex, ex)
-        for e in graph.out_edges(ex):
-            graph.add_memlet_path(e.src, dst_ex,
-                                  src_conn=e.src_conn,
-                                  dst_conn=ConstAssignmentMapFusion.connector_counterpart(cmap.get(e.src_conn)),
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.add_memlet_path(dst_ex, e.dst,
-                                  src_conn=cmap.get(e.src_conn), dst_conn=e.dst_conn,
-                                  memlet=Memlet.from_memlet(e.data))
-            graph.remove_edge(e)
-
     def apply(self, graph: SDFGState, sdfg: SDFG):
         first_entry, first_exit, second_entry, second_exit = self.map_nodes(graph)
 
         # By now, we know that the two maps are compatible, not reading anything, and just blindly writing constants
         # _consistently_.
-        is_const_assignment, assignments = self.consistent_const_assignment_table(graph, first_entry, first_exit)
+        is_const_assignment, assignments = consistent_const_assignment_table(graph, first_entry, first_exit)
         assert is_const_assignment
 
         # Rename in case loop variables are named differently.
@@ -476,10 +470,10 @@ class ConstAssignmentMapFusion(MapFusion):
         second_entry.map.params = first_entry.map.params
 
         # Consolidate the incoming dependencies of the two maps.
-        self.consolidate_empty_dependencies(graph, first_entry, second_entry)
+        consolidate_empty_dependencies(graph, first_entry, second_entry)
 
         # Consolidate the written access nodes of the two maps.
-        self.consolidate_written_nodes(graph, first_exit, second_exit)
+        consolidate_written_nodes(graph, first_exit, second_exit)
 
         # If the ranges are identical, then simply fuse the two maps. Otherwise, use grid-strided loops.
         en, ex = graph.add_map(sdfg._find_new_name('map_fusion_wrapper'),
@@ -488,9 +482,9 @@ class ConstAssignmentMapFusion(MapFusion):
                                schedule=first_entry.map.schedule)
         for cur_en, cur_ex in [(first_entry, first_exit), (second_entry, second_exit)]:
             if en.map.range.covers(cur_en.map.range):
-                self.consume_map_exactly(graph, (en, ex), (cur_en, cur_ex))
+                consume_map_exactly(graph, (en, ex), (cur_en, cur_ex))
             else:
-                self.consume_map_with_grid_strided_loop(graph, (en, ex), (cur_en, cur_ex))
+                consume_map_with_grid_strided_loop(graph, (en, ex), (cur_en, cur_ex))
 
         # Cleanup: remove duplicate empty dependencies.
         seen = set()
@@ -529,9 +523,7 @@ class ConstAssignmentStateFusion(StateFusionExtended):
             en, ex = en_ex
             if any(not e.data.is_empty for e in st.in_edges(en)):
                 return False
-            is_const_assignment, further_assignments = ConstAssignmentMapFusion.consistent_const_assignment_table(st,
-                                                                                                                  en,
-                                                                                                                  ex)
+            is_const_assignment, further_assignments = consistent_const_assignment_table(st, en, ex)
             if not is_const_assignment:
                 return False
             for k, v in further_assignments.items():
@@ -540,8 +532,7 @@ class ConstAssignmentStateFusion(StateFusionExtended):
                 assignments[k] = v
 
         # Moreover, both states' ranges must be compatible.
-        if not ConstAssignmentMapFusion.compatible_range(unique_top_level_map_node(st0)[0],
-                                                         unique_top_level_map_node(st1)[0]):
+        if not compatible_range(unique_top_level_map_node(st0)[0], unique_top_level_map_node(st1)[0]):
             return False
 
         return True

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from itertools import chain
 from typing import Optional, Union
 
-from dace import transformation, SDFGState, SDFG, Memlet, subsets
+from dace import transformation, SDFGState, SDFG, Memlet, subsets, ScheduleType
 from dace.sdfg import nodes
 from dace.sdfg.graph import OrderedDiGraph
 from dace.sdfg.nodes import Tasklet, ExitNode, MapEntry, MapExit, NestedSDFG, Node, EntryNode, AccessNode
@@ -404,7 +404,8 @@ class ConstAssignmentMapFusion(MapFusion):
                       for p, rs, rd in zip(dst_en.map.params, src_en.map.range.ranges, dst_en.map.range.ranges)]
         gsl_params = [f"gsl_{p}" for p in dst_en.map.params]
         en, ex = graph.add_map(graph.sdfg._find_new_name('gsl'),
-                               {k: v for k, v in zip(gsl_params, gsl_ranges)})
+                               {k: v for k, v in zip(gsl_params, gsl_ranges)},
+                               schedule=ScheduleType.Sequential)
         # graph.add_memlet_path(dst_en, en, memlet=Memlet())
         ConstAssignmentMapFusion.consume_map_exactly(graph, (en, ex), src)
         # graph.add_memlet_path(ex, dst_ex, memlet=Memlet())

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -1,0 +1,149 @@
+import ast
+from itertools import chain
+
+import dace.subsets
+from dace import transformation, SDFGState, SDFG, Memlet
+from dace.sdfg import nodes
+from dace.sdfg.nodes import Tasklet, ExitNode
+from dace.transformation.dataflow import MapFusion
+
+
+class ConstAssignmentMapFusion(MapFusion):
+    first_map_exit = transformation.PatternNode(nodes.ExitNode)
+    array = transformation.PatternNode(nodes.AccessNode)
+    second_map_entry = transformation.PatternNode(nodes.EntryNode)
+
+    # NOTE: `expression()` is inherited.
+
+    @staticmethod
+    def consistent_const_assignment_table(graph, en, ex) -> tuple[bool, dict]:
+        table = {}
+        for n in graph.all_nodes_between(en, ex):
+            # Each of the nodes in this map must be...
+            if not isinstance(n, Tasklet):
+                # ...a tasklet...
+                return False, table
+            if len(n.code.code) != 1 or not isinstance(n.code.code[0], ast.Assign):
+                # ...that assigns...
+                return False, table
+            op = n.code.code[0]
+            if not isinstance(op.value, ast.Constant) or len(op.targets) != 1:
+                # ...a constant to a single target.
+                return False, table
+            const = op.value.value
+            for oe in graph.out_edges(n):
+                dst = oe.data
+                dst_arr = oe.data.data
+                if dst_arr in table and table[dst_arr] != const:
+                    # A target array can appear multiple times, but it must always be consistently assigned.
+                    return False, table
+                table[dst] = const
+                table[dst_arr] = const
+        return True, table
+
+    def map_nodes(self, graph: SDFGState):
+        return (graph.entry_node(self.first_map_exit), self.first_map_exit,
+                self.second_map_entry, graph.exit_node(self.second_map_entry))
+
+    def can_be_applied(self, graph: SDFGState, expr_index: int, sdfg: SDFG, permissive: bool = False) -> bool:
+        first_entry, first_exit, second_entry, second_exit = self.map_nodes(graph)
+        # TODO(pratyai): Make a better check for map compatibility.
+        if first_entry.map.range != second_entry.map.range or first_entry.map.schedule != second_entry.map.schedule:
+            # TODO(pratyai): Make it so that a permutation of the ranges, or even an union of the ranges will work.
+            return False
+
+        # Both maps must have consistent constant assignment for the target arrays.
+        is_const_assignment, assignments = self.consistent_const_assignment_table(graph, first_entry, first_exit)
+        if not is_const_assignment:
+            return False
+        is_const_assignment, further_assignments = self.consistent_const_assignment_table(graph, second_entry,
+                                                                                          second_exit)
+        if not is_const_assignment:
+            return False
+        for k, v in further_assignments.items():
+            if k in assignments and v != assignments[k]:
+                return False
+            assignments[k] = v
+        return True
+
+    @staticmethod
+    def track_access_nodes(graph: SDFGState, first_exit: ExitNode, second_exit: ExitNode):
+        # Track all the access nodes that will survive the purge.
+        access_nodes, remove_nodes = {}, set()
+        dst_nodes = set(e.dst for e in chain(graph.out_edges(first_exit), graph.out_edges(second_exit)))
+        for n in dst_nodes:
+            if n.data in access_nodes:
+                remove_nodes.add(n)
+            else:
+                access_nodes[n.data] = n
+        for n in remove_nodes:
+            assert n.data in access_nodes
+            assert access_nodes[n.data] != n
+        return access_nodes, remove_nodes
+
+    @staticmethod
+    def make_equivalent_connections(first_exit: ExitNode, second_exit: ExitNode):
+        # Set up the extra connections on the first node.
+        conn_map = {}
+        for c, v in second_exit.in_connectors.items():
+            assert c.startswith('IN_')
+            cbase = c.removeprefix('IN_')
+            sc = first_exit.next_connector(cbase)
+            conn_map[f"IN_{cbase}"] = f"IN_{sc}"
+            conn_map[f"OUT_{cbase}"] = f"OUT_{sc}"
+            first_exit.add_in_connector(f"IN_{sc}", dtype=v)
+            first_exit.add_out_connector(f"OUT_{sc}", dtype=v)
+        for c, v in second_exit.out_connectors.items():
+            assert c in conn_map
+        return conn_map
+
+    def apply(self, graph: SDFGState, sdfg: SDFG):
+        first_entry, first_exit, second_entry, second_exit = self.map_nodes(graph)
+
+        # By now, we know that the two maps are compatible, not reading anything, and just blindly writing constants
+        # _consistently_.
+        is_const_assignment, assignments = self.consistent_const_assignment_table(graph, first_entry, first_exit)
+        assert is_const_assignment
+
+        # Track all the access nodes that will survive the purge.
+        access_nodes, remove_nodes = self.track_access_nodes(graph, first_exit, second_exit)
+
+        # Set up the extra connections on the first node.
+        conn_map = self.make_equivalent_connections(first_exit, second_exit)
+
+        # Redirect outgoing edges from exit nodes that are going to be invalidated.
+        for e in graph.out_edges(first_exit):
+            array_name = e.dst.data
+            assert array_name in access_nodes
+            if access_nodes[array_name] != e.dst:
+                graph.add_memlet_path(first_exit, access_nodes[array_name], src_conn=e.src_conn, dst_conn=e.dst_conn,
+                                      memlet=Memlet(str(e.data)))
+                graph.remove_edge(e)
+        for e in graph.out_edges(second_exit):
+            array_name = e.dst.data
+            assert array_name in access_nodes
+            graph.add_memlet_path(first_exit, access_nodes[array_name], src_conn=conn_map[e.src_conn],
+                                  dst_conn=e.dst_conn, memlet=Memlet(str(e.data)))
+            graph.remove_edge(e)
+
+        # Move the tasklets from the second map into the first map.
+        second_tasklets = graph.all_nodes_between(second_entry, second_exit)
+        for t in second_tasklets:
+            for e in graph.in_edges(t):
+                graph.add_memlet_path(first_entry, t, memlet=Memlet())
+                graph.remove_edge(e)
+            for e in graph.out_edges(t):
+                graph.add_memlet_path(e.src, first_exit, src_conn=e.src_conn, dst_conn=conn_map[e.dst_conn],
+                                      memlet=Memlet(str(e.data)))
+                graph.remove_edge(e)
+
+        # Redirect any outgoing edges from the nodes to be removed through their surviving counterparts.
+        for n in remove_nodes:
+            for e in graph.out_edges(n):
+                if e.dst != second_entry:
+                    alt_n = access_nodes[n.data]
+                    memlet = Memlet(str(e.data)) if not e.data.is_empty() else Memlet()
+                    graph.add_memlet_path(alt_n, e.dst, src_conn=e.src_conn, dst_conn=e.dst_conn, memlet=memlet)
+            graph.remove_node(n)
+        graph.remove_node(second_entry)
+        graph.remove_node(second_exit)

--- a/dace/transformation/dataflow/const_assignment_fusion.py
+++ b/dace/transformation/dataflow/const_assignment_fusion.py
@@ -393,13 +393,14 @@ class ConstAssignmentMapFusion(MapFusion):
         dst_en, dst_ex = dst
         src_en, src_ex = src
 
-        def with_start_and_stride(r, start, stride):
+        def range_for_grid_stride(r, val, bound):
             r = list(r)
-            r[0] = start
-            r[2] = stride
+            r[0] = val
+            r[1] = bound - 1
+            r[2] = bound
             return tuple(r)
 
-        gsl_ranges = [with_start_and_stride(rd, p, rs[1] + 1)
+        gsl_ranges = [range_for_grid_stride(rd, p, rs[1] + 1)
                       for p, rs, rd in zip(dst_en.map.params, src_en.map.range.ranges, dst_en.map.range.ranges)]
         gsl_params = [f"gsl_{p}" for p in dst_en.map.params]
         en, ex = graph.add_map(graph.sdfg._find_new_name('gsl'),

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -7,6 +7,7 @@ import dace
 from dace.transformation.dataflow.const_assignment_fusion import ConstAssignmentMapFusion, ConstAssignmentStateFusion
 from dace.transformation.interstate import StateFusionExtended
 
+K = dace.symbol('K')
 M = dace.symbol('M')
 N = dace.symbol('N')
 
@@ -152,6 +153,47 @@ def test_free_floating_fusion():
 
 
 @dace.program
+def assign_top_face(A: dace.float32[K, M, N]):
+    for t1, t2 in dace.map[0:M, 0:N]:
+        A[0, t1, t2] = 1
+
+
+@dace.program
+def assign_bottom_face(A: dace.float32[K, M, N]):
+    for t1, t2 in dace.map[0:M, 0:N]:
+        A[K - 1, t1, t2] = 1
+
+
+@dace.program
+def assign_bounary_3d(A: dace.float32[K, M, N], B: dace.float32[K, M, N]):
+    assign_top_face(A)
+    assign_bottom_face(B)
+
+
+def test_fusion_with_multiple_indices():
+    A = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
+    B = np.random.uniform(size=(3, 4, 5)).astype(np.float32)
+
+    # Construct SDFG with the maps on separate states.
+    g = assign_bounary_3d.to_sdfg(simplify=True, validate=True, use_cache=False)
+    g.save(os.path.join('_dacegraphs', '3d-0.sdfg'))
+    g.validate()
+    actual_A = deepcopy(A)
+    actual_B = deepcopy(B)
+    g(A=actual_A, B=actual_B, K=3, M=4, N=5)
+
+    g.apply_transformations(ConstAssignmentMapFusion)
+    g.save(os.path.join('_dacegraphs', '3d-1.sdfg'))
+    g.validate()
+    our_A = deepcopy(A)
+    our_B = deepcopy(B)
+    g(A=our_A, B=our_B, K=3, M=4, N=5)
+
+    # print(our_A)
+    assert np.allclose(our_A, actual_A)
+
+
+@dace.program
 def assign_bounary_with_branch(A: dace.float32[M, N], B: dace.float32[M, N]):
     assign_top_row_branched(A)
     assign_bottom_row(B)
@@ -185,3 +227,4 @@ if __name__ == '__main__':
     test_interstate_fusion()
     test_free_floating_fusion()
     test_fusion_with_branch()
+    test_fusion_with_multiple_indices()

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -77,15 +77,19 @@ def test_within_state_fusion():
     g.save(os.path.join('_dacegraphs', 'simple-1.sdfg'))
     g.validate()
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'simple-2.sdfg'))
     g.validate()
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'simple-3.sdfg'))
     g.validate()
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion) == 0
+    assert g.apply_transformations(ConstAssignmentMapFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'simple-4.sdfg'))
     g.validate()
     our_A = deepcopy(A)
@@ -105,15 +109,19 @@ def test_interstate_fusion():
     actual_A = deepcopy(A)
     g(A=actual_A, M=4, N=5)
 
-    g.apply_transformations(ConstAssignmentStateFusion)
+    assert g.apply_transformations(ConstAssignmentStateFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'interstate-1.sdfg'))
     g.validate()
 
-    g.apply_transformations(ConstAssignmentStateFusion)
+    assert g.apply_transformations(ConstAssignmentStateFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'interstate-2.sdfg'))
     g.validate()
 
-    g.apply_transformations(ConstAssignmentStateFusion)
+    assert g.apply_transformations(ConstAssignmentStateFusion) == 0
+    assert g.apply_transformations(ConstAssignmentStateFusion,
+                                   options={'use_grid_strided_loops': True}) == 1
     g.save(os.path.join('_dacegraphs', 'interstate-3.sdfg'))
     g.validate()
     our_A = deepcopy(A)
@@ -141,7 +149,7 @@ def test_free_floating_fusion():
     actual_B = deepcopy(B)
     g(A=actual_A, B=actual_B, M=4, N=5)
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion) == 1
     g.save(os.path.join('_dacegraphs', 'floating-1.sdfg'))
     g.validate()
     our_A = deepcopy(A)
@@ -182,7 +190,7 @@ def test_fusion_with_multiple_indices():
     actual_B = deepcopy(B)
     g(A=actual_A, B=actual_B, K=3, M=4, N=5)
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion) == 1
     g.save(os.path.join('_dacegraphs', '3d-1.sdfg'))
     g.validate()
     our_A = deepcopy(A)
@@ -211,7 +219,7 @@ def test_fusion_with_branch():
     actual_B = deepcopy(B)
     g(A=actual_A, B=actual_B, M=4, N=5)
 
-    g.apply_transformations(ConstAssignmentMapFusion)
+    assert g.apply_transformations(ConstAssignmentMapFusion) == 1
     g.save(os.path.join('_dacegraphs', 'branched-1.sdfg'))
     g.validate()
     our_A = deepcopy(A)

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -13,26 +13,26 @@ N = dace.symbol('N')
 
 @dace.program
 def assign_top_row(A: dace.float32[M, N]):
-    for i in dace.map[0:N]:
-        A[0, i] = 1
+    for t in dace.map[0:N]:
+        A[0, t] = 1
 
 
 @dace.program
 def assign_bottom_row(A: dace.float32[M, N]):
-    for i in dace.map[0:N]:
-        A[M - 1, i] = 1
+    for b in dace.map[0:N]:
+        A[M - 1, b] = 1
 
 
 @dace.program
 def assign_left_col(A: dace.float32[M, N]):
-    for i in dace.map[0:M]:
-        A[i, 0] = 1
+    for l in dace.map[0:M]:
+        A[l, 0] = 1
 
 
 @dace.program
 def assign_right_col(A: dace.float32[M, N]):
-    for i in dace.map[0:M]:
-        A[i, N - 1] = 1
+    for r in dace.map[0:M]:
+        A[r, N - 1] = 1
 
 
 def assign_bounary_sdfg():

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -16,6 +16,12 @@ def assign_top_row(A: dace.float32[M, N]):
     for t in dace.map[0:N]:
         A[0, t] = 1
 
+@dace.program
+def assign_top_row_branched(A: dace.float32[M, N]):
+    for t, in dace.map[0:N]:
+        if t % 2 == 0:
+            A[0, t] = 1
+
 
 @dace.program
 def assign_bottom_row(A: dace.float32[M, N]):
@@ -144,6 +150,37 @@ def test_free_floating_fusion():
     assert np.allclose(our_A, actual_A)
 
 
+@dace.program
+def assign_bounary_with_branch(A: dace.float32[M, N], B: dace.float32[M, N]):
+    assign_top_row_branched(A)
+    assign_bottom_row(B)
+
+
+def test_fusion_with_branch():
+    A = np.random.uniform(size=(4, 5)).astype(np.float32)
+    B = np.random.uniform(size=(4, 5)).astype(np.float32)
+
+    # Construct SDFG with the maps on separate states.
+    g = assign_bounary_with_branch.to_sdfg(simplify=True)
+    g.save(os.path.join('_dacegraphs', 'branched-0.sdfg'))
+    g.validate()
+    actual_A = deepcopy(A)
+    actual_B = deepcopy(B)
+    g(A=actual_A, B=actual_B, M=4, N=5)
+
+    g.apply_transformations(ConstAssignmentMapFusion)
+    g.save(os.path.join('_dacegraphs', 'branched-1.sdfg'))
+    g.validate()
+    our_A = deepcopy(A)
+    our_B = deepcopy(B)
+    g(A=our_A, B=our_B, M=4, N=5)
+
+    # print(our_A)
+    assert np.allclose(our_A, actual_A)
+
+
 if __name__ == '__main__':
     test_within_state_fusion()
     test_interstate_fusion()
+    test_free_floating_fusion()
+    test_fusion_with_branch()

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -1,0 +1,110 @@
+import os
+from copy import deepcopy
+
+import numpy as np
+
+import dace
+from dace.sdfg import nodes
+from dace.transformation.dataflow.const_assignment_fusion import ConstAssignmentMapFusion
+from dace.transformation.interstate import StateFusionExtended
+
+M = dace.symbol('M')
+N = dace.symbol('N')
+
+
+@dace.program
+def assign_top_row(A: dace.float32[M, N]):
+    for i in dace.map[0:N]:
+        A[0, i] = 1
+
+
+@dace.program
+def assign_bottom_row(A: dace.float32[M, N]):
+    for i in dace.map[0:N]:
+        A[M - 1, i] = 1
+
+
+@dace.program
+def assign_left_col(A: dace.float32[M, N]):
+    for i in dace.map[0:M]:
+        A[i, 0] = 1
+
+
+@dace.program
+def assign_right_col(A: dace.float32[M, N]):
+    for i in dace.map[0:M]:
+        A[i, N - 1] = 1
+
+
+def assign_bounary_sdfg():
+    st0 = assign_top_row.to_sdfg(simplify=True, validate=True)
+    st0.start_block.label = 'st0'
+
+    st1 = assign_bottom_row.to_sdfg(simplify=True, validate=True)
+    st1.start_block.label = 'st1'
+    st0.add_edge(st0.start_state, st1.start_state, dace.InterstateEdge())
+
+    st2 = assign_left_col.to_sdfg(simplify=True, validate=True)
+    st2.start_block.label = 'st2'
+    st0.add_edge(st1.start_state, st2.start_state, dace.InterstateEdge())
+
+    st3 = assign_right_col.to_sdfg(simplify=True, validate=True)
+    st3.start_block.label = 'st3'
+    st0.add_edge(st2.start_state, st3.start_state, dace.InterstateEdge())
+
+    return st0
+
+
+def find_access_node_by_name(g, name):
+    """ Finds the first data node by the given name"""
+    return next((n, s) for n, s in g.all_nodes_recursive()
+                if isinstance(n, nodes.AccessNode) and name == n.data)
+
+
+def find_map_entry_by_name(g, name):
+    """ Finds the first map entry node by the given name """
+    return next((n, s) for n, s in g.all_nodes_recursive()
+                if isinstance(n, nodes.MapEntry) and n.label.startswith(name))
+
+
+def find_map_exit_by_name(g, name):
+    """ Finds the first map entry node by the given name """
+    return next((n, s) for n, s in g.all_nodes_recursive()
+                if isinstance(n, nodes.MapExit) and n.label.startswith(name))
+
+
+def test_within_state_fusion():
+    A = np.random.uniform(size=(4, 5)).astype(np.float32)
+
+    # Construct SDFG with the maps on separate states.
+    g = assign_bounary_sdfg()
+    g.save(os.path.join('_dacegraphs', 'simple-0.sdfg'))
+    g.validate()
+    actual_A = deepcopy(A)
+    g(A=actual_A, M=4, N=5)
+
+    # Fuse the two states so that the const-assignment-fusion is applicable.
+    g.apply_transformations_repeated(StateFusionExtended, validate_all=True)
+    g.save(os.path.join('_dacegraphs', 'simple-1.sdfg'))
+    g.validate()
+
+    g.apply_transformations(ConstAssignmentMapFusion)
+    g.save(os.path.join('_dacegraphs', 'simple-2.sdfg'))
+    g.validate()
+
+    g.apply_transformations(ConstAssignmentMapFusion)
+    g.save(os.path.join('_dacegraphs', 'simple-3.sdfg'))
+    g.validate()
+
+    g.apply_transformations(ConstAssignmentMapFusion)
+    g.save(os.path.join('_dacegraphs', 'simple-4.sdfg'))
+    g.validate()
+    our_A = deepcopy(A)
+    g(A=our_A, M=4, N=5)
+
+    print(our_A)
+    assert np.allclose(our_A, actual_A)
+
+
+if __name__ == '__main__':
+    test_within_state_fusion()

--- a/tests/transformations/const_assignment_fusion_test.py
+++ b/tests/transformations/const_assignment_fusion_test.py
@@ -16,6 +16,7 @@ def assign_top_row(A: dace.float32[M, N]):
     for t in dace.map[0:N]:
         A[0, t] = 1
 
+
 @dace.program
 def assign_top_row_branched(A: dace.float32[M, N]):
     for t, in dace.map[0:N]:
@@ -42,18 +43,18 @@ def assign_right_col(A: dace.float32[M, N]):
 
 
 def assign_bounary_sdfg():
-    st0 = assign_top_row.to_sdfg(simplify=True, validate=True)
+    st0 = assign_top_row.to_sdfg(simplify=True, validate=True, use_cache=False)
     st0.start_block.label = 'st0'
 
-    st1 = assign_bottom_row.to_sdfg(simplify=True, validate=True)
+    st1 = assign_bottom_row.to_sdfg(simplify=True, validate=True, use_cache=False)
     st1.start_block.label = 'st1'
     st0.add_edge(st0.start_state, st1.start_state, dace.InterstateEdge())
 
-    st2 = assign_left_col.to_sdfg(simplify=True, validate=True)
+    st2 = assign_left_col.to_sdfg(simplify=True, validate=True, use_cache=False)
     st2.start_block.label = 'st2'
     st0.add_edge(st1.start_state, st2.start_state, dace.InterstateEdge())
 
-    st3 = assign_right_col.to_sdfg(simplify=True, validate=True)
+    st3 = assign_right_col.to_sdfg(simplify=True, validate=True, use_cache=False)
     st3.start_block.label = 'st3'
     st0.add_edge(st2.start_state, st3.start_state, dace.InterstateEdge())
 
@@ -132,7 +133,7 @@ def test_free_floating_fusion():
     B = np.random.uniform(size=(4, 5)).astype(np.float32)
 
     # Construct SDFG with the maps on separate states.
-    g = assign_bounary_free_floating.to_sdfg(simplify=True)
+    g = assign_bounary_free_floating.to_sdfg(simplify=True, validate=True, use_cache=False)
     g.save(os.path.join('_dacegraphs', 'floating-0.sdfg'))
     g.validate()
     actual_A = deepcopy(A)
@@ -161,7 +162,7 @@ def test_fusion_with_branch():
     B = np.random.uniform(size=(4, 5)).astype(np.float32)
 
     # Construct SDFG with the maps on separate states.
-    g = assign_bounary_with_branch.to_sdfg(simplify=True)
+    g = assign_bounary_with_branch.to_sdfg(simplify=True, validate=True, use_cache=False)
     g.save(os.path.join('_dacegraphs', 'branched-0.sdfg'))
     g.validate()
     actual_A = deepcopy(A)


### PR DESCRIPTION
## Test script:

```python
def test_big():
    m, n = 1000, 2000
    A = np.random.uniform(size=(n, m)).astype(np.float32)

    def original_op():
        g = assign_bounary_sdfg()  # Construct SDFG with the maps on separate states.
        g.simplify()
        g.validate()
        g.compile()
        return g

    def fused_op():
        g = assign_bounary_sdfg()  # Construct SDFG with the maps on separate states.
        g.apply_transformations_repeated(ConstAssignmentStateFusion)
        g.simplify()
        g.validate()
        g.compile()
        return g

    # === Part 1: Original Op === #
    g = deepcopy(original_op())
    # g.instrument = dace.InstrumentationType.Timer
    actual_A = deepcopy(A)
    with dace.profile(repetitions=100, warmup=10) as prof:
        g(A=actual_A, M=m, N=n)
    print(prof.report)

    # === Part 2: Fused Op === #
    g = deepcopy(fused_op())
    # g.instrument = dace.InstrumentationType.Timer
    our_A = deepcopy(A)
    with dace.profile(repetitions=100, warmup=10) as prof:
        g(A=our_A, M=m, N=n)
    print(prof.report)
```

## Output:

```
(venv) pmazumder@einstein:~/gitspace/dace$ python -m pytest tests/transformations/const_assignment_fusion_test.py -k big -s
=============================================================== test session starts ================================================================
platform linux -- Python 3.12.7, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/pmazumder/gitspace/dace
configfile: pytest.ini
collected 5 items / 4 deselected / 1 selected                                                                                                      

Profiling: 100%|████████████████████████████████████████████████████████████████████████████████████████████████| 110/110 [00:00<00:00, 3514.74it/s]
const_assignment_fusion_test_assign_top_row 0.1728162169456482 ms
Instrumentation report
SDFG Hash: 83fec8a6656b2984c46b254e1b9bcfa07e797b3a908d320cddd1f907c32bf8ed
---------------------------------------------------------------------------
Element        Runtime (ms)   
               Min            Mean           Median         Max            
---------------------------------------------------------------------------
SDFG (0)                                                                   
|:                                                                         
|              0.151          0.172          0.173          0.195          
---------------------------------------------------------------------------

Profiling: 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 110/110 [00:00<00:00, 10664.14it/s]
const_assignment_fusion_test_assign_top_row 0.08606910705566406 ms
Instrumentation report
SDFG Hash: e48cf6d17c62dd6f83205d490e464529ad073f4cab52f496ef1e4d7d2636ce0b
---------------------------------------------------------------------------
Element        Runtime (ms)   
               Min            Mean           Median         Max            
---------------------------------------------------------------------------
SDFG (0)                                                                   
|:                                                                         
|              0.072          0.088          0.086          0.160          
---------------------------------------------------------------------------
```